### PR TITLE
Start lazy actor when calling close

### DIFF
--- a/common/kotlinx-coroutines-core-common/src/CoroutineScope.kt
+++ b/common/kotlinx-coroutines-core-common/src/CoroutineScope.kt
@@ -163,7 +163,7 @@ public object GlobalScope : CoroutineScope {
  *      ... load some UI data ...
  *   }
  *
- *   withContext(UI) {
+ *   withContext(Dispatchers.Main) {
  *     doSomeWork()
  *     val result = data.await()
  *     display(result)

--- a/common/kotlinx-coroutines-core-common/src/channels/Channel.kt
+++ b/common/kotlinx-coroutines-core-common/src/channels/Channel.kt
@@ -111,7 +111,7 @@ public interface SendChannel<in E> {
      *   events.offer(event)
      * }
      *
-     * val uiUpdater = launch(UI, parent = UILifecycle) {
+     * val uiUpdater = launch(Dispatchers.Main, parent = UILifecycle) {
      *    events.consume {}
      *    events.cancel()
      * }

--- a/core/kotlinx-coroutines-core/src/ThreadContextElement.kt
+++ b/core/kotlinx-coroutines-core/src/ThreadContextElement.kt
@@ -40,7 +40,7 @@ import kotlin.coroutines.*
  * }
  *
  * // Usage
- * launch(UI + CoroutineName("Progress bar coroutine")) { ... }
+ * launch(Dispatchers.Main + CoroutineName("Progress bar coroutine")) { ... }
  * ```
  *
  * Every time this coroutine is resumed on a thread, UI thread name is updated to
@@ -90,7 +90,7 @@ public interface ThreadContextElement<S> : CoroutineContext.Element {
  * println(myThreadLocal.get()) // Prints "null"
  * launch(Dispatchers.Default + myThreadLocal.asContextElement(value = "foo")) {
  *   println(myThreadLocal.get()) // Prints "foo"
- *   withContext(UI) {
+ *   withContext(Dispatchers.Main) {
  *     println(myThreadLocal.get()) // Prints "foo", but it's on UI thread
  *   }
  * }
@@ -101,7 +101,7 @@ public interface ThreadContextElement<S> : CoroutineContext.Element {
  *
  * ```
  * myThreadLocal.set("main")
- * withContext(UI) {
+ * withContext(Dispatchers.Main) {
  *   println(myThreadLocal.get()) // Prints "main"
  *   myThreadLocal.set("UI")
  * }

--- a/core/kotlinx-coroutines-core/src/channels/Actor.kt
+++ b/core/kotlinx-coroutines-core/src/channels/Actor.kt
@@ -156,6 +156,11 @@ private class LazyActorCoroutine<E>(
         return super.offer(element)
     }
 
+    override fun close(cause: Throwable?): Boolean {
+        start()
+        return super.close(cause)
+    }
+
     override val onSend: SelectClause2<E, SendChannel<E>>
         get() = this
 

--- a/core/kotlinx-coroutines-core/test/channels/ActorLazyTest.kt
+++ b/core/kotlinx-coroutines-core/test/channels/ActorLazyTest.kt
@@ -61,4 +61,22 @@ class ActorLazyTest : TestBase() {
         assertThat(actor.isClosedForSend, IsEqual(true))
         finish(6)
     }
+
+    @Test
+    fun testCloseFreshActor() = runTest {
+        val job = launch {
+            expect(2)
+            val actor = actor<Int>(start = CoroutineStart.LAZY) {
+                expect(3)
+                for (i in channel) { }
+                expect(4)
+            }
+
+            actor.close()
+        }
+
+        expect(1)
+        job.join()
+        finish(5)
+    }
 }

--- a/core/kotlinx-coroutines-core/test/channels/ActorTest.kt
+++ b/core/kotlinx-coroutines-core/test/channels/ActorTest.kt
@@ -169,4 +169,16 @@ class ActorTest(private val capacity: Int) : TestBase() {
         parent.join()
         finish(2)
     }
+
+    @Test
+    fun testCloseFreshActor() = runTest {
+        for (start in CoroutineStart.values()) {
+            val job = launch {
+                val actor = actor<Int>(start = start) { for (i in channel) {} }
+                actor.close()
+            }
+
+            job.join()
+        }
+    }
 }

--- a/core/kotlinx-coroutines-core/test/scheduling/CoroutineSchedulerStressTest.kt
+++ b/core/kotlinx-coroutines-core/test/scheduling/CoroutineSchedulerStressTest.kt
@@ -78,7 +78,7 @@ class CoroutineSchedulerStressTest : TestBase() {
 
         finishLatch.await()
 
-        require(blockingThread!! !in observedThreads)
+        require(!observedThreads.containsKey(blockingThread!!))
         validateResults()
     }
 

--- a/native/kotlinx-coroutines-core-native/src/CoroutineContext.kt
+++ b/native/kotlinx-coroutines-core-native/src/CoroutineContext.kt
@@ -8,7 +8,7 @@ import kotlin.coroutines.*
 import kotlinx.coroutines.internal.*
 
 private fun takeEventLoop(): EventLoopImpl =
-    ThreadLocalEventLoop.currentOrNull() as EventLoopImpl ?:
+    ThreadLocalEventLoop.currentOrNull() as? EventLoopImpl ?:
         error("There is no event loop. Use runBlocking { ... } to start one.")
 
 internal object DefaultExecutor : CoroutineDispatcher(), Delay {

--- a/native/kotlinx-coroutines-core-native/src/CoroutineExceptionHandlerImpl.kt
+++ b/native/kotlinx-coroutines-core-native/src/CoroutineExceptionHandlerImpl.kt
@@ -8,5 +8,5 @@ import kotlin.coroutines.*
 
 internal actual fun handleCoroutineExceptionImpl(context: CoroutineContext, exception: Throwable) {
     // log exception
-    println(exception)
+    exception.printStackTrace()
 }

--- a/native/kotlinx-coroutines-core-native/test/DelayExceptionTest.kt
+++ b/native/kotlinx-coroutines-core-native/test/DelayExceptionTest.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines
+
+import kotlin.coroutines.*
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class DelayExceptionTest {
+    private object Dispatcher : CoroutineDispatcher() {
+        override fun isDispatchNeeded(context: CoroutineContext): Boolean = true
+        override fun dispatch(context: CoroutineContext, block: Runnable) { block.run() }
+    }
+
+    private lateinit var exception: Throwable
+
+
+    @Test
+    fun testThrowsTce() {
+        CoroutineScope(Dispatcher + CoroutineExceptionHandler { _, e -> exception = e }).launch {
+            delay(10)
+        }
+
+        assertTrue(exception is IllegalStateException)
+    }
+}


### PR DESCRIPTION
Rationale:
While it is possible to atomically transition state machine to "completed", it has multiple caveats:
  * It breaks intuition that "close" allows actors to process remaining messages and call its body
  * It introduces one more internal API dependency
  * It makes behaviour of non-lazy and lazy actors inconsistent

Fixes #939